### PR TITLE
Add batching to vector store document embedding ingestion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 #### An agentic AI pipeline for multiple, large PDF reports interrogation
 
 ### Set up
-- Clone this repostiory into a local directory of your choosing
+- Clone this repository into a local directory of your choosing
 - Build a virtual environment 
 - Install `knowai` by running:  `pip install .` from the root directory of your clone (OR) install using `pip install knowai` from PyPI.
 - Configure a `.env` file with the following:
@@ -14,8 +14,9 @@
     - `AZURE_OPENAI_ENDPOINT` - Your Azure endpoint
     - `AZURE_OPENAI_DEPLOYMENT` - Your LLM deployment name (e.g., "gpt-4o")
     - `AZURE_EMBEDDINGS_DEPLOYMENT` - Your embeddings model deployment name (e.g., "text-embedding-3-large", defaults to "text-embedding-3-large")
-- `AZURE_OPENAI_API_VERSION` - Your Azure LLM deployment version (e.g., "2024-02-01")
-- `AZURE_OPENAI_EMBEDDINGS_API_VERSION` - Your Azure embeddings API version (e.g., "2024-02-01", defaults to "2024-02-01")
+    - `AZURE_OPENAI_API_VERSION` - Your Azure LLM deployment version (e.g., "2024-02-01")
+    - `AZURE_OPENAI_EMBEDDINGS_API_VERSION` - Your Azure embeddings API version (e.g., "2024-02-01", defaults to "2024-02-01")
+    - `VECTORSTORE_EMBEDDING_BATCH_SIZE` - Optional number of chunks to embed per vectorstore write batch. Defaults to `50`.
 
 ### Building the vectorstore
 
@@ -37,10 +38,22 @@ retriever = get_retriever_from_directory(
     persist_directory="my_vectorstore",
     metadata_parquet_path="metadata.parquet",
     k=10,
-    chunk_size=1000,
+    chunk_size=1400,
     chunk_overlap=200
 )
 ```
+
+#### PDF ingestion and embedding batches
+When building a vectorstore, KnowAI processes each PDF page by page. Text is extracted with PyMuPDF, using standard text extraction first and a block-based fallback when a page has no standard text. Page text is split into overlapping chunks, very short chunks are skipped, and each retained chunk is stored as a LangChain `Document` with the chunk text plus metadata from the parquet file.
+
+Each chunk also gets provenance fields that make retrieval traceable:
+
+- `file_name`
+- `source_path`
+- `page`
+- `chunk_index`
+
+Embedding writes are batched by default to avoid sending oversized inputs to the embeddings model. New chunks are embedded and added to FAISS in batches of up to `50` documents unless `VECTORSTORE_EMBEDDING_BATCH_SIZE` is set. When updating an existing vectorstore, KnowAI checks existing `file_name` and `page` metadata and skips pages already present in the FAISS store.
 
 #### Inspecting Vectorstores
 To inspect an existing vectorstore:
@@ -360,10 +373,13 @@ python -m pytest
 # Test specific functionality
 python -m pytest tests/test_prompts.py -v
 python -m pytest tests/test_agent.py -v
+python -m pytest tests/test_vectorstore.py -v
 
 # Test no-chunks feedback improvements
 python scripts/test_no_chunks_feedback.py
 ```
+
+The vectorstore tests cover default embedding batching, `VECTORSTORE_EMBEDDING_BATCH_SIZE` overrides, incremental updates to existing FAISS stores, and metadata-aware vectorstore inspection utilities.
 
 ## Contributing
 

--- a/knowai/vectorstore.py
+++ b/knowai/vectorstore.py
@@ -28,20 +28,23 @@ from .utils import get_azure_credentials
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_VECTORSTORE_EMBEDDING_BATCH_SIZE = 50
+
 
 def _get_vectorstore_batch_size(total_docs: int) -> int:
     raw_value = os.environ.get("VECTORSTORE_EMBEDDING_BATCH_SIZE")
     if raw_value is None:
-        return max(1, total_docs)
+        return max(1, min(DEFAULT_VECTORSTORE_EMBEDDING_BATCH_SIZE, total_docs))
 
     try:
         return max(1, int(raw_value))
     except ValueError:
         logger.warning(
-            "Invalid VECTORSTORE_EMBEDDING_BATCH_SIZE=%s; embedding all documents in one batch",
+            "Invalid VECTORSTORE_EMBEDDING_BATCH_SIZE=%s; using default batch size %s",
             raw_value,
+            DEFAULT_VECTORSTORE_EMBEDDING_BATCH_SIZE,
         )
-        return max(1, total_docs)
+        return max(1, min(DEFAULT_VECTORSTORE_EMBEDDING_BATCH_SIZE, total_docs))
 
 
 def _document_batches(docs: List[Document], batch_size: int):

--- a/knowai/vectorstore.py
+++ b/knowai/vectorstore.py
@@ -29,6 +29,26 @@ from .utils import get_azure_credentials
 logger = logging.getLogger(__name__)
 
 
+def _get_vectorstore_batch_size(total_docs: int) -> int:
+    raw_value = os.environ.get("VECTORSTORE_EMBEDDING_BATCH_SIZE")
+    if raw_value is None:
+        return max(1, total_docs)
+
+    try:
+        return max(1, int(raw_value))
+    except ValueError:
+        logger.warning(
+            "Invalid VECTORSTORE_EMBEDDING_BATCH_SIZE=%s; embedding all documents in one batch",
+            raw_value,
+        )
+        return max(1, total_docs)
+
+
+def _document_batches(docs: List[Document], batch_size: int):
+    for start in range(0, len(docs), batch_size):
+        yield docs[start:start + batch_size]
+
+
 def process_pdfs_to_documents(
     directory_path: str,
     metadata_map: dict,
@@ -199,11 +219,16 @@ def get_retriever_from_docs(
         return None
 
     # Build or update vectorstore
+    batch_size = _get_vectorstore_batch_size(len(new_docs))
     if vectorstore:
-        vectorstore.add_documents(new_docs)
+        if new_docs:
+            for batch in _document_batches(new_docs, batch_size):
+                vectorstore.add_documents(batch)
         logger.info(f"Added {len(new_docs)} new chunks to FAISS store")
     else:
-        vectorstore = FAISS.from_documents(documents=new_docs, embedding=embeddings)
+        vectorstore = FAISS.from_documents(documents=new_docs[:batch_size], embedding=embeddings)
+        for batch in _document_batches(new_docs[batch_size:], batch_size):
+            vectorstore.add_documents(batch)
         logger.info(f"Created new FAISS store with {len(new_docs)} chunks")
 
     # Persist if required

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,11 @@ build-backend = "hatchling.build"
 
 [project]
 name = "knowai"
-version = "0.5.0"
+version = "0.6.0"
 license = {file = "LICENSE"}
 authors = [
   { name="Chris R. Vernon", email="chris.vernon@pnnl.gov" },
+  { name="Tycko P. Franklin", email="tycko.franklin@pnnl.gov" },
 ]
 description = "A conversational RAG agent pipeline using LangGraph"
 readme = "README.md"

--- a/tests/test_vectorstore.py
+++ b/tests/test_vectorstore.py
@@ -7,12 +7,16 @@ import tempfile
 import os
 from unittest.mock import patch, MagicMock
 import pandas as pd
+from langchain_core.documents import Document
 
+import knowai.vectorstore as vectorstore_module
 from knowai.vectorstore import (
     get_azure_credentials,
+    get_retriever_from_docs,
     show_vectorstore_schema,
     list_vectorstore_files,
-    analyze_vectorstore_chunking
+    analyze_vectorstore_chunking,
+    DEFAULT_VECTORSTORE_EMBEDDING_BATCH_SIZE
 )
 
 
@@ -39,6 +43,145 @@ class TestVectorstoreUtils:
         with patch.dict(os.environ, {}, clear=True):
             credentials = get_azure_credentials()
             assert credentials is None
+
+    def test_get_retriever_batches_embeddings_by_default(self, monkeypatch):
+        """Large document sets should be embedded in bounded batches by default."""
+        calls = []
+
+        class FakeVectorstore:
+            def __init__(self, docs):
+                self.docstore = MagicMock()
+                self.docstore._dict = {}
+                self.docs = list(docs)
+
+            def add_documents(self, docs):
+                calls.append(("add", len(docs)))
+                self.docs.extend(docs)
+
+            def save_local(self, persist_directory):
+                calls.append(("save", persist_directory))
+
+            def as_retriever(self, search_kwargs):
+                self.search_kwargs = search_kwargs
+                return self
+
+        def fake_from_documents(documents, embedding):
+            calls.append(("from", len(documents)))
+            return FakeVectorstore(documents)
+
+        monkeypatch.delenv("VECTORSTORE_EMBEDDING_BATCH_SIZE", raising=False)
+        monkeypatch.setattr(vectorstore_module.os.path, "exists", lambda _: False)
+        monkeypatch.setattr(vectorstore_module, "get_azure_credentials", lambda: {"ok": True})
+        monkeypatch.setattr(vectorstore_module.FAISS, "from_documents", staticmethod(fake_from_documents))
+
+        docs = [
+            Document(page_content=f"chunk {i}", metadata={"file_name": "large.pdf", "page": i})
+            for i in range(DEFAULT_VECTORSTORE_EMBEDDING_BATCH_SIZE * 2 + 5)
+        ]
+
+        retriever = get_retriever_from_docs(
+            docs=docs,
+            persist_directory="unused",
+            persist=True,
+            embeddings=object(),
+        )
+
+        assert retriever is not None
+        assert calls == [
+            ("from", DEFAULT_VECTORSTORE_EMBEDDING_BATCH_SIZE),
+            ("add", DEFAULT_VECTORSTORE_EMBEDDING_BATCH_SIZE),
+            ("add", 5),
+            ("save", "unused"),
+        ]
+
+    def test_get_retriever_uses_configured_embedding_batch_size(self, monkeypatch):
+        """VECTORSTORE_EMBEDDING_BATCH_SIZE should override the default batch size."""
+        calls = []
+
+        class FakeVectorstore:
+            def __init__(self, docs):
+                self.docstore = MagicMock()
+                self.docstore._dict = {}
+                self.docs = list(docs)
+
+            def add_documents(self, docs):
+                calls.append(("add", len(docs)))
+                self.docs.extend(docs)
+
+            def as_retriever(self, search_kwargs):
+                return self
+
+        def fake_from_documents(documents, embedding):
+            calls.append(("from", len(documents)))
+            return FakeVectorstore(documents)
+
+        monkeypatch.setenv("VECTORSTORE_EMBEDDING_BATCH_SIZE", "2")
+        monkeypatch.setattr(vectorstore_module.os.path, "exists", lambda _: False)
+        monkeypatch.setattr(vectorstore_module, "get_azure_credentials", lambda: {"ok": True})
+        monkeypatch.setattr(vectorstore_module.FAISS, "from_documents", staticmethod(fake_from_documents))
+
+        docs = [
+            Document(page_content=f"chunk {i}", metadata={"file_name": "large.pdf", "page": i})
+            for i in range(5)
+        ]
+
+        retriever = get_retriever_from_docs(
+            docs=docs,
+            persist_directory="unused",
+            persist=False,
+            embeddings=object(),
+        )
+
+        assert retriever is not None
+        assert calls == [("from", 2), ("add", 2), ("add", 1)]
+
+    def test_get_retriever_batches_additions_to_existing_vectorstore(self, monkeypatch):
+        """Incremental updates should also use bounded embedding batches."""
+        calls = []
+
+        class FakeVectorstore:
+            def __init__(self):
+                self.docstore = MagicMock()
+                self.docstore._dict = {}
+
+            def add_documents(self, docs):
+                calls.append(("add", len(docs)))
+
+            def save_local(self, persist_directory):
+                calls.append(("save", persist_directory))
+
+            def as_retriever(self, search_kwargs):
+                return self
+
+        fake_vectorstore = FakeVectorstore()
+
+        monkeypatch.delenv("VECTORSTORE_EMBEDDING_BATCH_SIZE", raising=False)
+        monkeypatch.setattr(vectorstore_module.os.path, "exists", lambda _: True)
+        monkeypatch.setattr(vectorstore_module, "get_azure_credentials", lambda: {"ok": True})
+        monkeypatch.setattr(
+            vectorstore_module.FAISS,
+            "load_local",
+            staticmethod(lambda *args, **kwargs: fake_vectorstore),
+        )
+
+        docs = [
+            Document(page_content=f"chunk {i}", metadata={"file_name": "large.pdf", "page": i})
+            for i in range(DEFAULT_VECTORSTORE_EMBEDDING_BATCH_SIZE + 5)
+        ]
+
+        retriever = get_retriever_from_docs(
+            docs=docs,
+            persist_directory="existing",
+            persist=True,
+            embeddings=object(),
+        )
+
+        assert retriever is fake_vectorstore
+        assert calls == [
+            ("add", DEFAULT_VECTORSTORE_EMBEDDING_BATCH_SIZE),
+            ("add", 5),
+            ("save", "existing"),
+        ]
     
     def test_show_vectorstore_schema_none(self):
         """Test schema display with None vectorstore."""


### PR DESCRIPTION
Goal: it shouldn't affect current workflows unless they opt in, and it just sends the embeddings in batches instead of all at once.
 